### PR TITLE
Hide scrollbar from main-nav on Firefox

### DIFF
--- a/bitsandpieces/styles/main.css
+++ b/bitsandpieces/styles/main.css
@@ -319,6 +319,7 @@ pre code {
 
 .main-nav {
   box-sizing: border-box;
+  scrollbar-width: none;
   height: 100vh;
   left: 0;
   overflow-x: hidden;


### PR DESCRIPTION
Hides the scrollbar for the nav-panel (main-nav) on Firefox (Tested on FF 68 and Chromium 81)